### PR TITLE
Fix: Ghostty double instance on launch

### DIFF
--- a/update_system.1h.sh
+++ b/update_system.1h.sh
@@ -286,10 +286,7 @@ EOF
         "Ghostty")
             # Ghostty terminal
             if [[ -d "/Applications/Ghostty.app" ]]; then
-                # Force focus first
-                osascript -e 'tell application "Ghostty" to activate'
-                # Use zsh -c to ensure the quoted command string is parsed correctly
-                open -a Ghostty --args -e zsh -c "$cmd; exec zsh"
+                open -na Ghostty --args -e zsh -c "$cmd; exec zsh"
             else
                 # Fallback to Terminal
                 osascript -e "tell app \"Terminal\" to activate" -e "tell app \"Terminal\" to do script \"$cmd\""


### PR DESCRIPTION
When triggering an update from the SwiftBar menu, two Ghostty instances appear in the dock—one blank and one running the update commands.

This fix removes `osascript` pre-activation for Ghostty terminal launch. The `osascript -e 'tell application "Ghostty" to activate'` call before `open -na Ghostty` was launching a blank Ghostty instance, causing a second process to spawn when `open -na` subsequently created its own. Removing the pre-activation lets `open -na` handle both launching and command execution in a single instance.

Unlike iTerm2 and Terminal.app (which support AppleScript-based window/command creation), Ghostty on macOS currently lacks IPC for sending commands to a running instance ([ghostty-org/ghostty#2353](https://github.com/ghostty-org/ghostty/discussions/2353)).